### PR TITLE
swap bot and own message position

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -31,13 +31,13 @@ body {
   max-width:75%;
   width: auto;
   line-height: 18px;
-  align-self: flex-start;
+  align-self: flex-end;
 }
 
 .msgs li.bot {
   background: #6666fe;
   color: #fff;
-  align-self: flex-end;
+  align-self: flex-start;
 }
 
 .msgs li.bot span {


### PR DESCRIPTION
most other chat apps show the user's own message on the right and messages from others on the left